### PR TITLE
[fix] issue #1: プラグインパラメータ「共有対象スイッチ番号」もしくは「共有対象変数番号」を設定していないと正常動作しない不…

### DIFF
--- a/src/plugin/ts/UTA_CommonSaveMZ.ts
+++ b/src/plugin/ts/UTA_CommonSaveMZ.ts
@@ -13,14 +13,14 @@
  * @text 共有対象スイッチ番号
  * @desc セーブデータ間で共有するスイッチ番号の定義です。
  * 「-」で範囲指定が可能です。
- * @default
+ * @default []
  * @type string[]
  *
  * @param targetVariables
  * @text 共有対象変数番号
  * @desc セーブデータ間で共有する変数番号の定義です。
  * 「-」で範囲指定が可能です。
- * @default
+ * @default []
  * @type string[]
  *
  * @param applyOnLoad
@@ -256,10 +256,14 @@ namespace utakata {
             this.parameters = <CommonSavePluginParameters>PluginManager.parameters(this.PLUGIN_NAME);
 
             // プラグインパラメータに指定された値を読み込む
-            var targetSwitchesList: string[] = JsonEx.parse(this.parameters.targetSwitches);
-            var targetVariablesList: string[] = JsonEx.parse(this.parameters.targetVariables);
-            this.loadTargetSwitchesNumber(targetSwitchesList);
-            this.loadTargetVariablesNumber(targetVariablesList);
+            try {
+                var targetSwitchesList: string[] = this.parameters.targetSwitches ? JsonEx.parse(this.parameters.targetSwitches) : [];
+                var targetVariablesList: string[] = this.parameters.targetVariables ? JsonEx.parse(this.parameters.targetVariables) : [];
+                this.loadTargetSwitchesNumber(targetSwitchesList);
+                this.loadTargetVariablesNumber(targetVariablesList);
+            } catch (e) {
+                throw new Error(this.PLUGIN_NAME + ": plugin parameter parse error: " + e.message);
+            }
         }
 
         /**


### PR DESCRIPTION
## 概要
プラグインパラメータ「共有対象スイッチ番号」もしくは「共有対象変数番号」を設定していないと正常動作しない不具合の修正。

- プラグインパラメータを引数に`JsonEx.parse`する際に空文字の場合は処理せず[]を返すように。
- 当該プラグインパラメータのデフォルト値を[]に変更。
    - ユーザーが意図的にパラメータを削除した場合、空文字が入る可能性がある。

既に作成された共有セーブデータファイルへの影響は無し。

## 関連issue
- [プラグインパラメータ「共有対象スイッチ番号」もしくは「共有対象変数番号」を設定していないと正常動作しない](https://github.com/t-akatsuki/UTA_CommonSaveMZ/issues/1)
